### PR TITLE
Lazy log message construction.

### DIFF
--- a/src/main/java/org/projectodd/rephract/FileLinkLogger.java
+++ b/src/main/java/org/projectodd/rephract/FileLinkLogger.java
@@ -16,9 +16,9 @@ public class FileLinkLogger implements LinkLogger {
     }
 
     @Override
-    public void log(String message) {
+    public void log(String message, Object... arguments) {
         try {
-            out.write( message + "\n" );
+            out.write( String.format(message, arguments) + "\n" );
             out.flush();
         } catch (IOException e) {
             System.err.println( message );

--- a/src/main/java/org/projectodd/rephract/LinkLogger.java
+++ b/src/main/java/org/projectodd/rephract/LinkLogger.java
@@ -2,6 +2,6 @@ package org.projectodd.rephract;
 
 public interface LinkLogger {
     
-    void log(String message);
+    void log(String message, Object... arguments);
 
 }

--- a/src/main/java/org/projectodd/rephract/NullLinkLogger.java
+++ b/src/main/java/org/projectodd/rephract/NullLinkLogger.java
@@ -3,7 +3,7 @@ package org.projectodd.rephract;
 public class NullLinkLogger implements LinkLogger {
 
     @Override
-    public void log(String message) {
+    public void log(String message, Object... arguments) {
         // NO-OP
     }
 

--- a/src/main/java/org/projectodd/rephract/mop/AbstractMetaObjectProtocolLinkStrategy.java
+++ b/src/main/java/org/projectodd/rephract/mop/AbstractMetaObjectProtocolLinkStrategy.java
@@ -27,7 +27,11 @@ public abstract class AbstractMetaObjectProtocolLinkStrategy implements MetaObje
     }
 
     public void log(String message, Object... arguments) {
-        this.logger.log(Thread.currentThread().getName() + ": " + getClass().getSimpleName() + ": " + message);
+        Object[] args = new Object[arguments.length + 2];
+        args[0] = Thread.currentThread().getName();
+        args[1] = getClass().getSimpleName();
+        System.arraycopy(arguments, 0, args, 2, arguments.length);
+        this.logger.log("%s: %s: " + message, args);
     }
 
     @Override

--- a/src/main/java/org/projectodd/rephract/mop/AbstractMetaObjectProtocolLinkStrategy.java
+++ b/src/main/java/org/projectodd/rephract/mop/AbstractMetaObjectProtocolLinkStrategy.java
@@ -26,7 +26,7 @@ public abstract class AbstractMetaObjectProtocolLinkStrategy implements MetaObje
         this.logger = new NullLinkLogger();
     }
 
-    public void log(String message) {
+    public void log(String message, Object... arguments) {
         this.logger.log(Thread.currentThread().getName() + ": " + getClass().getSimpleName() + ": " + message);
     }
 

--- a/src/main/java/org/projectodd/rephract/mop/ContextualLinkStrategy.java
+++ b/src/main/java/org/projectodd/rephract/mop/ContextualLinkStrategy.java
@@ -96,7 +96,7 @@ public abstract class ContextualLinkStrategy<T> extends BaseMetaObjectProtocolLi
         binder = binder.convert( Object.class, Object.class, getRuntimeContextClass(), String.class );
         guardBinder = guardBinder.convert( boolean.class, Object.class, getRuntimeContextClass(), String.class );
         
-        log( "[GET_PROPERTY] receiver=" + receiver + "; propName=" + propName );
+        log( "[GET_PROPERTY] receiver=%s; propName=%s", receiver, propName );
         
         return linkGetProperty(chain, receiver, propName, binder, guardBinder);
     }
@@ -153,7 +153,7 @@ public abstract class ContextualLinkStrategy<T> extends BaseMetaObjectProtocolLi
         binder = binder.convert( Object.class, Object.class, getRuntimeContextClass(), String.class );
         guardBinder = guardBinder.convert( boolean.class, Object.class, getRuntimeContextClass(), String.class );
         
-        log( "[GET_METHOD] receiver=" + receiver + "; propName=" + propName );
+        log( "[GET_METHOD] receiver=%s; propName=%s", receiver, propName );
         return linkGetMethod(chain, receiver, propName, binder, guardBinder);
     }
 
@@ -208,7 +208,7 @@ public abstract class ContextualLinkStrategy<T> extends BaseMetaObjectProtocolLi
         binder = binder.convert( void.class, Object.class, getRuntimeContextClass(), String.class, Object.class );
         guardBinder = guardBinder.convert( boolean.class, Object.class, getRuntimeContextClass(), String.class, Object.class );
 
-        log( "[SET_PROPERTY] receiver=" + receiver + "; propName=" + propName );
+        log( "[SET_PROPERTY] receiver=%s; propName=%s", receiver, propName );
         return linkSetProperty(chain, receiver, propName, value, binder, guardBinder);
     }
 
@@ -249,7 +249,7 @@ public abstract class ContextualLinkStrategy<T> extends BaseMetaObjectProtocolLi
         binder = binder.convert( Object.class, Object.class, getRuntimeContextClass(), Object.class, Object[].class );
         guardBinder = guardBinder.convert( boolean.class, Object.class, getRuntimeContextClass(), Object.class, Object[].class );
 
-        log( "[CALL] receiver=" + receiver );
+        log( "[CALL] receiver=%s", receiver );
         return linkCall(chain, receiver, self, callArgs, binder, guardBinder);
     }
 
@@ -281,7 +281,7 @@ public abstract class ContextualLinkStrategy<T> extends BaseMetaObjectProtocolLi
             guardBinder = guardBinder.filter(1, contextAcquisitionFilter());
         }
 
-        log( "[CONSTRUCT] receiver=" + receiver );
+        log( "[CONSTRUCT] receiver=%s", receiver );
         return linkConstruct(chain, receiver, callArgs, binder, guardBinder);
     }
 

--- a/src/main/java/org/projectodd/rephract/mop/NonContextualLinkStrategy.java
+++ b/src/main/java/org/projectodd/rephract/mop/NonContextualLinkStrategy.java
@@ -56,7 +56,7 @@ public abstract class NonContextualLinkStrategy extends BaseMetaObjectProtocolLi
             guardBinder = dropContext(guardBinder);
         }
         
-        log( "[GET_PROPERTY] receiver=" + receiver + "; propName=" + propName );
+        log( "[GET_PROPERTY] receiver=%s; propName=%s", receiver, propName );
         return linkGetProperty(chain, receiver, propName, binder, guardBinder);
     }
 
@@ -108,7 +108,7 @@ public abstract class NonContextualLinkStrategy extends BaseMetaObjectProtocolLi
         binder = binder.convert(Object.class, Object.class, String.class, Object.class);
         guardBinder = guardBinder.convert(boolean.class, Object.class, String.class, Object.class);
 
-        log( "[SET_PROPERTY] receiver=" + receiver + "; propName=" + propName );
+        log( "[SET_PROPERTY] receiver=%s; propName=%s", receiver, propName );
         return linkSetProperty(chain, receiver, propName, value, binder, guardBinder);
     }
 
@@ -159,7 +159,7 @@ public abstract class NonContextualLinkStrategy extends BaseMetaObjectProtocolLi
         binder = binder.convert(Object.class, Object.class, String.class);
         guardBinder = guardBinder.convert(boolean.class, Object.class, String.class);
 
-        log( "[GET_METHOD] receiver=" + receiver + "; propName=" + propName );
+        log( "[GET_METHOD] receiver=%s; propName=%s", receiver, propName );
         return linkGetMethod(chain, receiver, propName, binder, guardBinder);
     }
 
@@ -197,7 +197,7 @@ public abstract class NonContextualLinkStrategy extends BaseMetaObjectProtocolLi
             callArgs = (Object[]) args[3];
         }
 
-        log( "[CALL] receiver=" + receiver );
+        log( "[CALL] receiver=%s", receiver );
         return linkCall(chain, receiver, self, callArgs, binder, guardBinder);
     }
 
@@ -226,7 +226,7 @@ public abstract class NonContextualLinkStrategy extends BaseMetaObjectProtocolLi
             callArgs = (Object[]) args[2];
         }
 
-        log( "[CONSTRUCT] receiver=" + receiver );
+        log( "[CONSTRUCT] receiver=%s", receiver );
         return linkConstruct(chain, receiver, callArgs, binder, guardBinder);
     }
     

--- a/src/main/java/org/projectodd/rephract/mop/java/JavaClassLinkStrategy.java
+++ b/src/main/java/org/projectodd/rephract/mop/java/JavaClassLinkStrategy.java
@@ -31,7 +31,7 @@ public class JavaClassLinkStrategy extends NonContextualLinkStrategy {
     public StrategicLink linkGetProperty(StrategyChain chain, Object receiver, String propName, Binder binder, Binder guardBinder) throws NoSuchMethodException,
             IllegalAccessException {
 
-        log("receiver: " + receiver + " // " + propName);
+        log("receiver: %s // %s", receiver, propName );
 
         if (!(receiver instanceof Class)) {
             return chain.nextStrategy();
@@ -40,7 +40,7 @@ public class JavaClassLinkStrategy extends NonContextualLinkStrategy {
         Resolver resolver = getResolver((Class<?>) receiver);
         MethodHandle reader = resolver.getClassResolver().getPropertyReader(propName);
 
-        log("reader: " + reader);
+        log("reader: %s", reader);
 
         if (reader == null) {
             return chain.nextStrategy();


### PR DESCRIPTION
Found with some profiling that the calling Reference#toString() was being called a huge number of times, the source of the calls was logging.

This implementation will only end up calling the Reference#toString() in implementations of LinkLogger that use the toString()...e.g. FileLinkLogger.
