### PR TITLE
Failing test for replanning on multiple invocations for java methods.

### DIFF
--- a/src/main/java/org/projectodd/rephract/mop/java/JavaInstanceLinkStrategy.java
+++ b/src/main/java/org/projectodd/rephract/mop/java/JavaInstanceLinkStrategy.java
@@ -148,7 +148,7 @@ public class JavaInstanceLinkStrategy extends NonContextualLinkStrategy {
                         .filter(0, plan.getFilters())
                         .invoke(plan.getMethodHandle());
 
-                MethodHandle guard = getCallGuard(self, args, guardBinder);
+                MethodHandle guard = getCallGuard(receiver, args, guardBinder);
                 return new StrategicLink(method, guard);
             } else {
                 MethodHandle method = binder.drop(0)

--- a/src/main/java/org/projectodd/rephract/mop/java/JavaInstanceLinkStrategy.java
+++ b/src/main/java/org/projectodd/rephract/mop/java/JavaInstanceLinkStrategy.java
@@ -148,7 +148,7 @@ public class JavaInstanceLinkStrategy extends NonContextualLinkStrategy {
                         .filter(0, plan.getFilters())
                         .invoke(plan.getMethodHandle());
 
-                MethodHandle guard = getCallGuard(receiver, args, guardBinder);
+                MethodHandle guard = getCallGuard(self, args, guardBinder);
                 return new StrategicLink(method, guard);
             } else {
                 MethodHandle method = binder.drop(0)
@@ -156,7 +156,7 @@ public class JavaInstanceLinkStrategy extends NonContextualLinkStrategy {
                         .filter(1, plan.getFilters())
                         .invoke(plan.getMethodHandle());
 
-                MethodHandle guard = getCallGuard(receiver, args, guardBinder);
+                MethodHandle guard = getCallGuard(self, args, guardBinder);
                 return new StrategicLink(method, guard);
             }
 

--- a/src/test/java/org/projectodd/rephract/mop/java/JavaLinkStrategyTest.java
+++ b/src/test/java/org/projectodd/rephract/mop/java/JavaLinkStrategyTest.java
@@ -284,7 +284,23 @@ public class JavaLinkStrategyTest {
         
         assertThat( meltResult ).isEqualTo( "melting for: taco" );
     }
-    
+
+    @Test(timeout = 2000)
+    public void testMultipleInvocationsDoesNotReplan() throws Throwable {
+        CallSite callSite = linker.bootstrap("dyn:getMethod", Object.class, Object.class, String.class);
+
+        Cheese swiss = new Cheese("swiss", 2);
+
+        Object method = callSite.getTarget().invoke(swiss, "melt");
+
+        CallSite callSite2 = linker.bootstrap("dyn:call", Object.class, Object.class, Object.class, Object[].class );
+
+        for (int i = 0; i < 10000; i++) {
+            Object result = callSite2.getTarget().invoke( method, swiss, new Object[] { String.valueOf(i) } );
+            assertThat( result ).isEqualTo( "melting for: " + i );
+        }
+    }
+
     @Test
     public void testLinkJavaBeans_getMethod_fixed_withContext() throws Throwable {
 


### PR DESCRIPTION
This branch is just a failing test for a performance issue with invocation of java methods.

It looks like the guard invalidates the callsite on every invocation which results in a replan. Also, as replanning happens for every invocation it becomes progressively slower as it replans more links.

The guard expects the receiver to be assignable from self, in the case illustrated by the test this results in a guard test failure as the receiver (DynamicMethod) is not assignable from self (Cheese).

I'm not sure what the correct behaviour is here, but wanted to raise the issue all the same.

Also, in dynjs this issue presents itself as java integration being horrendously slow for any more than a few thousand invocations of an individual java method.  
